### PR TITLE
Don't format the shared EBS volume for every new EC2 instance

### DIFF
--- a/terraform/modules/stack/cluster/container_host/ebs.tpl
+++ b/terraform/modules/stack/cluster/container_host/ebs.tpl
@@ -12,8 +12,11 @@ cloud-init-per once install_efs_utils yum install -y amazon-efs-utils
 # Create /ebs folder
 cloud-init-per once mkdir_ebs mkdir -p ${ebs_host_path}
 
-# Format ebs volume
-cloud-init-per once format_ebs mkfs -t ext4 ${ebs_volume_id}
+# Format the EBS volume as ext4.  We only want to do this if the volume
+# hasn't already been formatted by another EC2 instance.
+#
+# See https://serverfault.com/a/975257/206273
+echo "blkid --match-token TYPE=ext4 ${ebs_volume_id} || mkfs --type ext4 ${ebs_volume_id}" >> format_ebs_volume.sh
 
 # Add /ebs to fstab
 cloud-init-per once mount_ebs echo -e '${ebs_volume_id} ${ebs_host_path} ext4 defaults,nofail 0 2' >> /etc/fstab

--- a/terraform/stack_staging/.terraform.lock.hcl
+++ b/terraform/stack_staging/.terraform.lock.hcl
@@ -2,8 +2,7 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "2.70.0"
-  constraints = "~> 2.69"
+  version = "2.70.0"
   hashes = [
     "h1:mM6eIaG1Gcrk47TveViXBO9YjY6nDaGukbED2bdo8Mk=",
   ]


### PR DESCRIPTION
We should format the EBS volume if and only if it's never been formatted before; otherwise instances should leave it alone.  Previously every new EC2 instance would format the volume on first boot, which deletes any in-progress tasks and reverts to the default config.

I've tested this in staging, and I'm just waiting for the prod instance to come back up before declaring it done.

Closes https://github.com/wellcomecollection/platform/issues/4307