### PR TITLE
Use gp3 for our persistent EBS volumes

### DIFF
--- a/terraform/modules/critical/ebs.tf
+++ b/terraform/modules/critical/ebs.tf
@@ -12,6 +12,8 @@ locals {
 resource "aws_ebs_volume" "ebs" {
   availability_zone = "eu-west-1a"
   size              = local.ebs_volume_size
+  
+  type = "gp3"
 
   tags = {
     Name = local.ebs_name


### PR DESCRIPTION
It's ~20% cheaper and the 3000 IOPS we previously got as burst are now available as sustained, for free.

I migrated these volumes manually on Friday, and nobody noticed. XD

Closes https://github.com/wellcomecollection/platform/issues/4906