### PR TITLE
Only run a single RDS instance for Archivematica

### DIFF
--- a/terraform/modules/critical/rds.tf
+++ b/terraform/modules/critical/rds.tf
@@ -69,7 +69,7 @@ resource "aws_rds_cluster" "archivematica" {
 }
 
 resource "aws_rds_cluster_instance" "archivematica" {
-  count = 2
+  count = 1
 
   identifier           = "${aws_rds_cluster.archivematica.cluster_identifier}-instance-${count.index}"
   cluster_identifier   = aws_rds_cluster.archivematica.id


### PR DESCRIPTION
We don't put much load on the database, and each db.r5.large costs ~$170/mo.