### PR TITLE
Use the new Lambda error alarm ARN for the workflow account

### DIFF
--- a/terraform/critical_prod/outputs.tf
+++ b/terraform/critical_prod/outputs.tf
@@ -12,11 +12,13 @@ output "interservice_security_group_id" {
 
 # TODO: Don't put these in the unencrypted state file!
 output "rds_username" {
-  value = local.rds_username
+  value     = local.rds_username
+  sensitive = true
 }
 
 output "rds_password" {
-  value = local.rds_password
+  value     = local.rds_password
+  sensitive = true
 }
 
 output "rds_host" {

--- a/terraform/critical_staging/outputs.tf
+++ b/terraform/critical_staging/outputs.tf
@@ -12,11 +12,13 @@ output "interservice_security_group_id" {
 
 # TODO: Don't put these in the unencrypted state file!
 output "rds_username" {
-  value = local.rds_username
+  value     = local.rds_username
+  sensitive = true
 }
 
 output "rds_password" {
-  value = local.rds_password
+  value     = local.rds_password
+  sensitive = true
 }
 
 output "rds_host" {

--- a/terraform/modules/critical/elasticache.tf
+++ b/terraform/modules/critical/elasticache.tf
@@ -13,7 +13,7 @@ resource "aws_elasticache_subnet_group" "archivematica" {
 resource "aws_elasticache_cluster" "archivematica" {
   cluster_id           = local.elasticache_id
   engine               = "redis"
-  node_type            = "cache.m4.large"
+  node_type            = "cache.m3.medium"
   num_cache_nodes      = 1
   parameter_group_name = "default.redis3.2"
   engine_version       = "3.2.10"

--- a/terraform/modules/critical/provider.tf
+++ b/terraform/modules/critical/provider.tf
@@ -1,3 +1,9 @@
-provider "aws" {
-  alias = "digitisation"
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+
+      configuration_aliases = [aws.digitisation]
+    }
+  }
 }

--- a/terraform/modules/critical/rds.tf
+++ b/terraform/modules/critical/rds.tf
@@ -73,7 +73,7 @@ resource "aws_rds_cluster_instance" "archivematica" {
 
   identifier           = "${aws_rds_cluster.archivematica.cluster_identifier}-instance-${count.index}"
   cluster_identifier   = aws_rds_cluster.archivematica.id
-  instance_class       = "db.r5.large"
+  instance_class       = var.namespace == "prod" ? "db.r5.large" : "db.t3.medium"
   db_subnet_group_name = aws_db_subnet_group.archivematica.name
   publicly_accessible  = false
 

--- a/terraform/modules/critical/s3_transfer_source.tf
+++ b/terraform/modules/critical/s3_transfer_source.tf
@@ -34,11 +34,9 @@ data "aws_iam_policy_document" "archivematica_transfer_source" {
 
     principals {
       identifiers = [
-        "arn:aws:iam::404315009621:role/digitisation-developer",
         "arn:aws:iam::975596993436:role/storage-developer",
-
-        # All the roles in the workflow account
-        "arn:aws:iam::299497370133:root",
+        "arn:aws:iam::404315009621:role/digitisation-developer",
+        "arn:aws:iam::299497370133:root",  # workflow account
       ]
 
       type = "AWS"

--- a/terraform/modules/stack/load_balancer/main.tf
+++ b/terraform/modules/stack/load_balancer/main.tf
@@ -5,7 +5,7 @@ resource "aws_alb" "load_balancer" {
   subnets = var.public_subnets
   security_groups = concat(
     var.service_lb_security_group_ids,
-    list(aws_security_group.external_lb_security_group.id)
+    [aws_security_group.external_lb_security_group.id]
   )
   idle_timeout = var.idle_timeout
 }

--- a/terraform/modules/stack/provider.tf
+++ b/terraform/modules/stack/provider.tf
@@ -1,7 +1,9 @@
-provider "aws" {
-  alias = "digitisation"
-}
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
 
-provider "aws" {
-  alias = "dns"
+      configuration_aliases = [aws.digitisation, aws.dns]
+    }
+  }
 }

--- a/terraform/stack_prod/locals.tf
+++ b/terraform/stack_prod/locals.tf
@@ -1,4 +1,7 @@
 locals {
-  lambda_error_alarm_arn = data.terraform_remote_state.shared_infra.outputs.lambda_error_alarm_arn
+  monitoring_outputs = data.terraform_remote_state.monitoring.outputs
+
+  lambda_error_alarm_arn = local.monitoring_outputs["workflow_lambda_error_alerts_topic_arn"]
+
   ecr_storage_service_repo_url = data.terraform_remote_state.shared_archivematica.outputs.ecr_storage_service_repo_url
 }

--- a/terraform/stack_prod/terraform.tf
+++ b/terraform/stack_prod/terraform.tf
@@ -69,3 +69,15 @@ data "terraform_remote_state" "shared_infra" {
     region = "eu-west-1"
   }
 }
+
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}

--- a/terraform/stack_staging/locals.tf
+++ b/terraform/stack_staging/locals.tf
@@ -1,4 +1,7 @@
 locals {
-  lambda_error_alarm_arn = data.terraform_remote_state.shared_infra.outputs.lambda_error_alarm_arn
-  ecr_storage_service_repo_url = data.terraform_remote_state.shared_archivematica.outputs.ecr_storage_service_repo_url
+  monitoring_outputs = data.terraform_remote_state.monitoring.outputs
+
+  lambda_error_alarm_arn = local.monitoring_outputs["workflow_lambda_error_alerts_topic_arn"]
+
+  ecr_storage_service_repo_url = data.terraform_remote_state.infra.outputs.ecr_storage_service_repo_url
 }

--- a/terraform/stack_staging/terraform.tf
+++ b/terraform/stack_staging/terraform.tf
@@ -46,18 +46,6 @@ data "terraform_remote_state" "infra" {
   }
 }
 
-data "terraform_remote_state" "shared_archivematica" {
-  backend = "s3"
-
-  config = {
-    role_arn = "arn:aws:iam::299497370133:role/workflow-read_only"
-
-    bucket = "wellcomecollection-workflow-infra"
-    key    = "terraform/archivematica-infra/infra.tfstate"
-    region = "eu-west-1"
-  }
-}
-
 data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
@@ -66,6 +54,18 @@ data "terraform_remote_state" "shared_infra" {
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/platform-infrastructure/shared.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/monitoring.tfstate"
     region = "eu-west-1"
   }
 }


### PR DESCRIPTION
Builds on https://github.com/wellcomecollection/platform-infrastructure/pull/233, for https://github.com/wellcomecollection/platform/issues/5245

Previously any alerts from failed Lambdas would disappear into the ether.