### PR TITLE
Update ECS service module to version with circuit breaker protection

### DIFF
--- a/terraform/modules/stack/base/main.tf
+++ b/terraform/modules/stack/base/main.tf
@@ -1,17 +1,17 @@
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.3.0"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.11.0"
   namespace = var.service_name
 }
 
 module "log_router_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.3.0"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.11.0"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.3.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.11.0"
 
   cpu    = var.cpu
   memory = var.memory
@@ -28,7 +28,7 @@ module "task_definition" {
 }
 
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.3.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.11.0"
 
   cluster_arn  = var.cluster_arn
   service_name = var.service_name


### PR DESCRIPTION
Enabling the ECS deployment circuit breaker , turns on detection of repeated failed attempts to start tasks as part of an ECS deployment and will "cancel" a deployment if a particular threshold for failed tasks is met.

See: https://github.com/wellcomecollection/platform/issues/5306

Note: This is applied.