### PR TITLE
Be explicit that we're enabling service discovery

### DIFF
--- a/terraform/modules/stack/base/main.tf
+++ b/terraform/modules/stack/base/main.tf
@@ -33,6 +33,7 @@ module "service" {
   cluster_arn  = var.cluster_arn
   service_name = var.service_name
 
+  enable_service_discovery       = true
   service_discovery_namespace_id = var.service_discovery_namespace_id
 
   task_definition_arn = module.task_definition.arn


### PR DESCRIPTION
We want service discovery for these services, but Terraform can't know that service discovery will definitely be enabled unless we tell it here. See the comment here: https://github.com/wellcomecollection/terraform-aws-ecs-service/blob/main/modules/service/main.tf#L1-L18