### PR TITLE
Tag packages when we start a transfer in Archivematica

### DIFF
--- a/lambdas/s3_start_transfer/README.md
+++ b/lambdas/s3_start_transfer/README.md
@@ -1,6 +1,42 @@
 # s3_start_transfer
 
-This Lambda notices uploads to the `wellcomecollection-archivematica-transfer-source` S3 bucket (and staging equivalent), and calls the Archivematica API to trigger a new transfer.
+This Lambda allows archivists to start processing a transfer package with Archivematica by uploading it to S3.
+
+A transfer package is a zip file containing the files, plus some metadata (including our catalogue reference and/or accession number).
+
+```mermaid
+graph TD
+    A[User uploads package<br/>to S3] -->|S3 PutObject notification| L{Lambda checks package<br/>has correct structure<br/>and metadata}
+    L -->|passes checks| S[trigger Archivematica transfer,<br/>upload 'success' log and<br/>tag S3 object]
+    L -->|fails checks| F[upload 'failed' log]
+
+    classDef failedNode fill:#f6b6bd;stroke:#e01b2f
+    class F failedNode
+
+    classDef successNode fill:#b0f7e2;stroke:#0b7051
+    class S successNode
+
+    classDef genericNode fill:#e8e8e8;stroke:#8f8f8f
+    class A,L genericNode
+```
+
+When a user uploads a package to the "transfer source" S3 bucket, this Lambda is triggered by a bucket notification.
+It then runs a series of checks on the Lambda, e.g.:
+
+*   does it have a `metadata.csv` in the right place?
+*   does the `metadata.csv` have the right fields?
+*   is the package structured correctly?
+
+It records a success/fail result by uploading a small log file alongside the original file, which includes instructions if the transfer package is rejected -- so users can diagnose issues without leaving S3.
+
+If it starts a transfer successfully, it tags the S3 object with the transfer ID.
+
+
+
+## Deployment
+
+This Lambda is automatically deployed with the latest version whenever you apply Terraform in `stack_staging` or `stack_prod`.
+
 
 
 ## Running tests
@@ -34,3 +70,5 @@ $ coverage report
 
     We should have two top-level folders configured as transfer sources: `/born-digital` and `/born-digital-accessions`.
     To fix, set up these folders as transfer sources.
+
+    See the bootstrapping docs elsewhere in this repo.

--- a/lambdas/s3_start_transfer/README.md
+++ b/lambdas/s3_start_transfer/README.md
@@ -37,6 +37,7 @@ It then runs a series of checks on the transfer package, e.g.:
 It records a success/fail result by uploading a small log file alongside the original file, which includes instructions if the transfer package is rejected -- so users can diagnose issues without leaving S3.
 
 If it starts a transfer successfully, it tags the S3 object with the transfer ID.
+These tags will be used by the (yet-to-be-written) transfer monitor Lambda to check for Archivematica failures and/or clean up the bucket.
 
 
 

--- a/lambdas/s3_start_transfer/README.md
+++ b/lambdas/s3_start_transfer/README.md
@@ -17,13 +17,13 @@ graph TD
     L -->|passes checks| S[trigger Archivematica transfer,<br/>upload 'success' log and<br/>tag S3 object]
     L -->|fails checks| F[upload 'failed' log]
 
-    classDef failedNode fill:#f6b6bd;stroke:#e01b2f
+    classDef failedNode fill:#e01b2f,stroke:#e01b2f,fill-opacity:0.15
     class F failedNode
 
-    classDef successNode fill:#b0f7e2;stroke:#0b7051
+    classDef successNode fill:#b0f7e2,stroke:#0b7051,fill-opacity:0.35
     class S successNode
 
-    classDef genericNode fill:#e8e8e8;stroke:#8f8f8f
+    classDef genericNode fill:#e8e8e8,stroke:#8f8f8f
     class A,L genericNode
 ```
 

--- a/lambdas/s3_start_transfer/README.md
+++ b/lambdas/s3_start_transfer/README.md
@@ -1,8 +1,15 @@
 # s3_start_transfer
 
-This Lambda allows archivists to start processing a transfer package with Archivematica by uploading it to S3.
-
+This Lambda tells Archivematica to process transfer packages which are uploaded to a "transfer source" S3 bucket.
 A transfer package is a zip file containing the files, plus some metadata (including our catalogue reference and/or accession number).
+
+*   For archivists, this means they can start processing a transfer package by uploading it to S3, rather than using the Archivematica dashboard.
+
+*   For the platform team, this means we can do some checks on packages before they're sent to Archivematica (e.g. that the metadata has been supplied correctly).
+
+
+
+## How it works
 
 ```mermaid
 graph TD

--- a/lambdas/s3_start_transfer/README.md
+++ b/lambdas/s3_start_transfer/README.md
@@ -28,7 +28,7 @@ graph TD
 ```
 
 When a user uploads a package to the "transfer source" S3 bucket, this Lambda is triggered by a bucket notification.
-It then runs a series of checks on the Lambda, e.g.:
+It then runs a series of checks on the transfer package, e.g.:
 
 *   does it have a `metadata.csv` in the right place?
 *   does the `metadata.csv` have the right fields?

--- a/lambdas/s3_start_transfer/src/s3_start_transfer.py
+++ b/lambdas/s3_start_transfer/src/s3_start_transfer.py
@@ -36,7 +36,11 @@ def _write_log(sess, logger, bucket, key, result, tags=None):
         Bucket=bucket,
         Key=log_key,
         Body=logger.text(),
-        Tagging=[{"Key": key, "Value": value} for key, value in tags.items() if value is not None],
+        Tagging=[
+            {"Key": key, "Value": value}
+            for key, value in tags.items()
+            if value is not None
+        ],
         # The object is uploaded by a Lambda running in the workflow account,
         # but the transfer bucket is owned by the digitisation bucket.
         #
@@ -104,12 +108,16 @@ def run_transfer(sess, *, bucket, key):
     # See https://github.com/wellcomecollection/platform/issues/4614
     try:
         try:
-            verify_s3_package(s3=sess.resource("s3"), logger=logger, bucket=bucket, key=key)
+            verify_s3_package(
+                s3=sess.resource("s3"), logger=logger, bucket=bucket, key=key
+            )
         except VerificationFailure:
             print(f"Verification error in s3://{bucket}/{key}")
             return
 
-        identifiers = get_identifiers(s3=sess.resource("s3"), logger=logger, bucket=bucket, key=key)
+        identifiers = get_identifiers(
+            s3=sess.resource("s3"), logger=logger, bucket=bucket, key=key
+        )
     except NotImplementedError as err:
         if str(err) in {
             "compression type 9 (deflate64)",
@@ -142,14 +150,14 @@ def run_transfer(sess, *, bucket, key):
             name=target_name,
             path=target_path,
             processing_config=processing_config,
-            accession_number=identifiers['accession_number'],
+            accession_number=identifiers["accession_number"],
         )
 
         tags = {
             "Archivematica-TransferId": transfer_id,
             "Archivematica-ProcessingConfig": processing_config,
-            "Archivematica-AccessionNumber": identifiers['accession_number'],
-            "Archivematica-CatalogueIdentifier": identifiers['dc.identifier'],
+            "Archivematica-AccessionNumber": identifiers["accession_number"],
+            "Archivematica-CatalogueIdentifier": identifiers["dc.identifier"],
             "Archivematica-TransferStartedAt": dt.datetime.now().isoformat(),
         }
 
@@ -162,7 +170,7 @@ def run_transfer(sess, *, bucket, key):
                     for (key, value) in tags.items()
                     if value is not None
                 ]
-            }
+            },
         )
     except Exception as err:
         logger.write(f"Error starting transfer: {err}")

--- a/lambdas/s3_start_transfer/src/s3_start_transfer.py
+++ b/lambdas/s3_start_transfer/src/s3_start_transfer.py
@@ -36,9 +36,6 @@ def _write_log(sess, logger, bucket, key, result, tags=None):
         Bucket=bucket,
         Key=log_key,
         Body=logger.text(),
-        Tagging=" ".join(
-            f"{key}={value}" for key, value in tags.items() if value is not None
-        ),
         # The object is uploaded by a Lambda running in the workflow account,
         # but the transfer bucket is owned by the digitisation bucket.
         #
@@ -46,6 +43,19 @@ def _write_log(sess, logger, bucket, key, result, tags=None):
         # account (e.g. archivists) can download/clean up the files.
         ACL="bucket-owner-full-control",
     )
+
+    if tags:
+        s3.put_object_tagging(
+            Bucket=bucket,
+            Key=log_key,
+            Tagging={
+                "TagSet": [
+                    {"Key": key, "Value": value}
+                    for key, value in tags.items()
+                    if value is not None
+                ]
+            },
+        )
 
 
 def verify_s3_package(*, s3, logger, bucket, key):

--- a/lambdas/s3_start_transfer/src/s3_start_transfer.py
+++ b/lambdas/s3_start_transfer/src/s3_start_transfer.py
@@ -36,11 +36,9 @@ def _write_log(sess, logger, bucket, key, result, tags=None):
         Bucket=bucket,
         Key=log_key,
         Body=logger.text(),
-        Tagging={"TagSet":[
-            {"Key": key, "Value": value}
-            for key, value in tags.items()
-            if value is not None
-        ]},
+        Tagging=" ".join(
+            f"{key}={value}" for key, value in tags.items() if value is not None
+        ),
         # The object is uploaded by a Lambda running in the workflow account,
         # but the transfer bucket is owned by the digitisation bucket.
         #

--- a/lambdas/s3_start_transfer/src/s3_start_transfer.py
+++ b/lambdas/s3_start_transfer/src/s3_start_transfer.py
@@ -118,7 +118,10 @@ def run_transfer(sess, *, bucket, key):
             print(
                 f"Skipping verification for s3://{bucket}/{key}, deflate64-compressed ZIP"
             )
-            accession_number = os.path.basename(os.path.splitext(key)[0])
+            identifiers = {
+                "accession_number": os.path.basename(os.path.splitext(key)[0]),
+                "dc.identifier": None,
+            }
         else:
             print(f"Unable to decompress s3://{bucket}/{key}: {err}")
             return

--- a/lambdas/s3_start_transfer/src/s3_start_transfer.py
+++ b/lambdas/s3_start_transfer/src/s3_start_transfer.py
@@ -36,11 +36,11 @@ def _write_log(sess, logger, bucket, key, result, tags=None):
         Bucket=bucket,
         Key=log_key,
         Body=logger.text(),
-        Tagging=[
+        Tagging={"TagSet":[
             {"Key": key, "Value": value}
             for key, value in tags.items()
             if value is not None
-        ],
+        ]},
         # The object is uploaded by a Lambda running in the workflow account,
         # but the transfer bucket is owned by the digitisation bucket.
         #

--- a/terraform/stack_staging/provider.tf
+++ b/terraform/stack_staging/provider.tf
@@ -9,7 +9,7 @@ locals {
 }
 
 provider "aws" {
-  region = var.region
+  region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::299497370133:role/workflow-admin"


### PR DESCRIPTION
For #104 and #106

When we trigger a transfer from an uploaded S3 object, we now tag the object with the transfer ID in Archivematica… the same transfer ID which will later be written to the storage service as the Internal-Sender-Identifier. This is useful for #106, because we can look in the bucket for objects with these transfer IDs, and if they're in the storage service, we know we can delete these objects.

I've also added a README to explain what this Lambda is for.