### PR TITLE
Add an Archivematica transfer monitor

### DIFF
--- a/lambdas/transfer_monitor/README.md
+++ b/lambdas/transfer_monitor/README.md
@@ -1,0 +1,17 @@
+# transfer_monitor
+
+This Lambda monitors the "transfer source" S3 bucket, and does two things:
+
+*   It posts a message to Slack telling us about transfers, including both successes and failures
+
+*   It cleans up leftover files from successful transfers, so the transfer bucket doesn't fill up with files which are duplicated in the storage service
+
+It's triggered on a schedule.
+
+It uses the tags written by the [s3_start_transfer Lambda](../s3_start_transfer) to match package in the transfer bucket to bags in the storage service.
+
+
+
+## Deployment
+
+This Lambda is automatically deployed with the latest version whenever you apply Terraform in `stack_staging` or `stack_prod`.

--- a/lambdas/transfer_monitor/src/transfer_monitor.py
+++ b/lambdas/transfer_monitor/src/transfer_monitor.py
@@ -1,0 +1,225 @@
+import datetime
+import functools
+import io
+import json
+import os
+from urllib.error import HTTPError
+import urllib.request
+import zipfile
+
+import boto3
+
+
+@functools.lru_cache
+def get_secret_string(sess, *, secret_id):
+    """
+    Look up the value of a SecretString in Secrets Manager.
+    """
+    secrets = sess.client("secretsmanager")
+    return secrets.get_secret_value(SecretId=secret_id)["SecretString"]
+
+
+@functools.lru_cache
+def has_matching_bag(*, archivematica_transfer_id, external_identifier, files_index):
+    """
+    Is there a bag with this external identifier and transfer ID in
+    the storage service?
+
+    We rely on a bit of knowledge about how Archivematica structures the
+    AIP: we know it's going to put a METS file at this location in the
+    package:
+
+        data/objects/submissionDocumentation/transfer-{package_name}-{transfer_id}/METS.xml
+
+    so by looking for a matching file in the storage service, we know
+    whether something was stored successfully.
+    """
+    sess = boto3.Session()
+    es_credentials = json.loads(
+        get_secret_string(
+            sess, secret_id="archivematica/transfer_monitor/reporting_credentials"
+        )
+    )
+
+    endpoint = es_credentials["endpoint"]
+    api_key = es_credentials["api_key"]
+
+    query = {
+        "query": {
+            "bool": {
+                "filter": [
+                    {"term": {"externalIdentifier": external_identifier}},
+                    {"term": {"suffix": "xml"}},
+                ]
+            }
+        },
+        "_source": ["name"],
+        "sort": [{"createdDate": {"order": "desc"}}],
+        "size": 100,
+    }
+
+    req = urllib.request.Request(
+        f"{es_credentials['endpoint']}/{files_index}/_search",
+        data=json.dumps(query).encode("utf-8"),
+        headers={"Authorization": f"ApiKey {api_key}", "Content-Type": "application/json"},
+    )
+
+    resp = urllib.request.urlopen(req)
+    es_resp = json.loads(resp.read())
+
+    return any(
+        h["_source"]["name"].endswith(f"-{archivematica_transfer_id}/METS.xml")
+        for h in es_resp["hits"]["hits"]
+    )
+
+
+def get_recent_objects(sess, *, bucket, days):
+    """
+    Generates recent objects in the S3 bucket, and their tags.
+    """
+    s3 = sess.client("s3")
+    paginator = s3.get_paginator("list_objects_v2")
+
+    last_modified_after = datetime.datetime.now() - datetime.timedelta(days=days)
+
+    for page in paginator.paginate(Bucket=bucket):
+        for s3_obj in page["Contents"]:
+
+            # Vanilla Python can only create offset-naive datetimes, whereas
+            # the S3 API returns a UTC datetime which is offset-aware.  Trying
+            # to compare the two gives an error:
+            #
+            #       TypeError: can't compare offset-naive and
+            #       offset-aware datetimes
+            #
+            # But this is only a loose heuristic, so it's okay to drop the
+            # timezone info from S3.
+            if s3_obj["LastModified"].replace(tzinfo=None) < last_modified_after:
+                continue
+
+            # Fetch the tags from S3 and attach them to the object.
+            tagging = s3.get_object_tagging(Bucket=bucket, Key=s3_obj["Key"])
+            s3_obj["Tags"] = {t["Key"]: t["Value"] for t in tagging["TagSet"]}
+
+            yield s3_obj
+
+
+def post_to_slack(*, webhook_url, results, days_to_check, environment):
+    if environment == "staging":
+        name = "Archivematica (staging)"
+    else:
+        name = "Archivematica"
+
+    if results["failed"] or results["succeeded"]:
+        summary = f"Here’s what happened in {name} in the last {days_to_check} day{'s' if days_to_check > 1 else ''}:"
+    else:
+        summary = f"Nothing happened in {name} in the last {days_to_check} day{'s' if days_to_check > 1 else ''}."
+
+    blocks = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": summary,
+            },
+        }
+    ]
+
+    failed_packages = [p for p in results["failed"] if p["Key"].endswith(".zip")]
+
+    if failed_packages:
+        if environment == "staging":
+            warning_emoji = "⚠️"
+        else:
+            warning_emoji = "🚨"
+
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "{warning_emoji} *These packages didn’t get stored successfully:*\n"
+                    + "\n".join(
+                        f'- {p["Key"]} (`{p["Tags"]["Archivematica-TransferId"]}`)'
+                        for p in failed_packages
+                    ),
+                },
+            }
+        )
+
+    succeeded_packages = [p for p in results["succeeded"] if p["Key"].endswith(".zip")]
+
+    if succeeded_packages:
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "These packages were stored successfully:\n"
+                    + "\n".join(f'- {p["Key"]}' for p in succeeded_packages),
+                },
+            }
+        )
+
+    slack_payload = {"username": "Archivematica transfer report", "blocks": blocks}
+
+    req = urllib.request.Request(
+        webhook_url,
+        data=json.dumps(slack_payload).encode("utf8"),
+        headers={"Content-Type": "application/json"},
+    )
+
+    try:
+        urllib.request.urlopen(req)
+    except HTTPError as err:
+        raise Exception(f"{err} - {err.read()}")
+
+
+def main(event, _):
+    sess = boto3.Session()
+
+    transfer_bucket = os.environ["TRANSFER_BUCKET"]
+    files_index = os.environ["REPORTING_FILES_INDEX"]
+    days_to_check = int(os.environ["DAYS_TO_CHECK"])
+    environment = os.environ["ENVIRONMENT"]
+
+    results = {"succeeded": [], "failed": []}
+
+    for s3_obj in get_recent_objects(sess, bucket=transfer_bucket, days=days_to_check):
+        if "Archivematica-TransferId" not in s3_obj["Tags"]:
+            continue
+
+        if has_matching_bag(
+            archivematica_transfer_id=s3_obj["Tags"]["Archivematica-TransferId"],
+            external_identifier=s3_obj["Tags"].get(
+                "Archivematica-CatalogueIdentifier",
+                s3_obj["Tags"].get("Archivematica-AccessionNumber"),
+            ),
+            files_index=files_index,
+        ):
+            results["succeeded"].append(s3_obj)
+        else:
+            results["failed"].append(s3_obj)
+
+    post_to_slack(
+        webhook_url=get_secret_string(
+            sess, secret_id="archivematica/transfer_monitoring/slack_webhook"
+        ),
+        results=results,
+        days_to_check=days_to_check,
+        environment=environment,
+    )
+
+    for s3_obj in results["succeeded"]:
+        kwargs = {"Bucket": transfer_bucket, "Key": s3_obj["Key"]}
+
+        try:
+            kwargs["VersionId"] = s3_obj["VersionId"]
+        except KeyError:
+            pass
+
+        sess.client("s3").delete_object(**kwargs)
+
+
+if __name__ == "__main__":
+    main(None, None)

--- a/lambdas/transfer_monitor/src/transfer_monitor.py
+++ b/lambdas/transfer_monitor/src/transfer_monitor.py
@@ -137,15 +137,7 @@ def post_to_slack(*, webhook_url, results, days_to_check, environment):
     else:
         summary = f"Nothing happened in {name} in the last {days_to_check} day{'s' if days_to_check > 1 else ''}."
 
-    blocks = [
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": summary,
-            },
-        }
-    ]
+    blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": summary}}]
 
     failed_packages = [p for p in results["failed"] if p["Key"].endswith(".zip")]
 

--- a/lambdas/transfer_monitor/src/transfer_monitor.py
+++ b/lambdas/transfer_monitor/src/transfer_monitor.py
@@ -67,7 +67,10 @@ def has_matching_bag(*, archivematica_transfer_id, external_identifier, files_in
     req = urllib.request.Request(
         f"{es_credentials['endpoint']}/{files_index}/_search",
         data=json.dumps(query).encode("utf-8"),
-        headers={"Authorization": f"ApiKey {api_key}", "Content-Type": "application/json"},
+        headers={
+            "Authorization": f"ApiKey {api_key}",
+            "Content-Type": "application/json",
+        },
     )
 
     resp = urllib.request.urlopen(req)
@@ -86,6 +89,8 @@ def get_recent_objects(sess, *, bucket, days):
     s3 = sess.client("s3")
     paginator = s3.get_paginator("list_objects_v2")
 
+    # TODO: Do we need to do a date restriction?  Could we look at
+    # the entire bucket every time?
     last_modified_after = datetime.datetime.now() - datetime.timedelta(days=days)
 
     for page in paginator.paginate(Bucket=bucket):
@@ -225,7 +230,7 @@ def main(event, _):
     # Send a message to Slack with a summary of the report.
     post_to_slack(
         webhook_url=get_secret_string(
-            sess, secret_id="archivematica/transfer_monitoring/slack_webhook"
+            sess, secret_id="archivematica/transfer_monitor/slack_webhook"
         ),
         results=results,
         days_to_check=days_to_check,
@@ -244,7 +249,3 @@ def main(event, _):
             pass
 
         sess.client("s3").delete_object(**kwargs)
-
-
-if __name__ == "__main__":
-    main(None, None)

--- a/lambdas/transfer_monitor/src/transfer_monitor.py
+++ b/lambdas/transfer_monitor/src/transfer_monitor.py
@@ -1,11 +1,9 @@
 import datetime
 import functools
-import io
 import json
 import os
 from urllib.error import HTTPError
 import urllib.request
-import zipfile
 
 import boto3
 
@@ -65,7 +63,7 @@ def has_matching_bag(*, archivematica_transfer_id, external_identifier, files_in
     }
 
     req = urllib.request.Request(
-        f"{es_credentials['endpoint']}/{files_index}/_search",
+        f"{endpoint}/{files_index}/_search",
         data=json.dumps(query).encode("utf-8"),
         headers={
             "Authorization": f"ApiKey {api_key}",
@@ -162,7 +160,7 @@ def post_to_slack(*, webhook_url, results, days_to_check, environment):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "{warning_emoji} *These packages didn’t get stored successfully:*\n"
+                    "text": f"{warning_emoji} *These packages didn’t get stored successfully:*\n"
                     + "\n".join(
                         f'- {p["Key"]} (`{p["Tags"]["Archivematica-TransferId"]}`)'
                         for p in failed_packages

--- a/terraform/modules/stack/lambda_transfer_monitor.tf
+++ b/terraform/modules/stack/lambda_transfer_monitor.tf
@@ -1,0 +1,77 @@
+module "transfer_monitor_lambda" {
+  source     = "./lambda"
+  handler    = "transfer_monitor.main"
+  source_dir = "${path.module}/../../../lambdas/transfer_monitor/src"
+
+  description     = "Report on the state of Archivematica transfers (${var.namespace})"
+  name            = "archivematica-transfer_monitor-${var.namespace}"
+  alarm_topic_arn = var.lambda_error_alarm_arn
+
+  environment = {
+    TRANSFER_BUCKET       = var.transfer_source_bucket_name
+    REPORTING_FILES_INDEX = var.namespace == "prod" ? "storage_files" : "storage_stage_files"
+    DAYS_TO_CHECK         = 14
+    ENVIRONMENT           = var.namespace
+  }
+
+  timeout = 300
+}
+
+data "aws_iam_policy_document" "allow_reading_and_deleting_from_uploads_bucket" {
+  statement {
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      var.transfer_source_bucket_arn,
+      "${var.transfer_source_bucket_arn}*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "allow_reading_and_deleting_from_uploads_bucket" {
+  role   = module.transfer_monitor_lambda.role_name
+  policy = data.aws_iam_policy_document.allow_reading_and_deleting_from_uploads_bucket.json
+}
+
+data "aws_iam_policy_document" "allow_reading_transfer_monitor_secrets" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      "arn:aws:secretsmanager:eu-west-1:299497370133:secret:archivematica/transfer_monitor/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "allow_reading_transfer_monitor_secrets" {
+  role   = module.transfer_monitor_lambda.role_name
+  policy = data.aws_iam_policy_document.allow_reading_transfer_monitor_secrets.json
+}
+
+# Schedule the reporter to run at 6:15 every Monday.  This is slightly
+# after the daily report from the storage service, so they'll always appear
+# in a consistent order.
+
+resource "aws_cloudwatch_event_rule" "every_monday_at_6_15" {
+  name                = "trigger_transfer_monitor"
+  schedule_expression = "cron(15 6 ? * MON *)"
+}
+
+resource "aws_lambda_permission" "allow_transfer_monitor_cloudwatch_trigger" {
+  action        = "lambda:InvokeFunction"
+  function_name = module.transfer_monitor_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.every_monday_at_6_15.arn
+}
+
+resource "aws_cloudwatch_event_target" "event_trigger" {
+  rule = aws_cloudwatch_event_rule.every_monday_at_6_15.name
+  arn  = module.transfer_monitor_lambda.arn
+}
+


### PR DESCRIPTION
Closes #104, for #105

This is a Lambda function that runs every Monday morning, and will tell us about everything that's happened in Archivematica that week. This is designed to give us more visibility of failures in particular, but as a nice side-effect it should help keep the transfer bucket clean – it automatically deletes any completed transfers.