### PR TITLE
Fix a bug in the Archivematica transfer monitor

### DIFF
--- a/lambdas/transfer_monitor/src/transfer_monitor.py
+++ b/lambdas/transfer_monitor/src/transfer_monitor.py
@@ -48,6 +48,11 @@ def has_matching_bag(*, archivematica_transfer_id, external_identifier, files_in
     #
     # This may be possible in future, see
     # https://github.com/wellcomecollection/storage-service/issues/1028
+    #
+    # If a transfer package contains lots of XML files, this lookup may
+    # fail because the METS file wasn't in the first 10,000 results.
+    # If that occurs, we should consider scheduling the storage service
+    # work in the ticket above, and
     query = {
         "query": {
             "bool": {
@@ -59,7 +64,7 @@ def has_matching_bag(*, archivematica_transfer_id, external_identifier, files_in
         },
         "_source": ["name"],
         "sort": [{"createdDate": {"order": "desc"}}],
-        "size": 100,
+        "size": 10000,
     }
 
     req = urllib.request.Request(

--- a/terraform/modules/stack/lambda_transfer_monitor.tf
+++ b/terraform/modules/stack/lambda_transfer_monitor.tf
@@ -59,7 +59,7 @@ resource "aws_iam_role_policy" "allow_reading_transfer_monitor_secrets" {
 # in a consistent order.
 
 resource "aws_cloudwatch_event_rule" "every_monday_at_6_15" {
-  name                = "trigger_transfer_monitor"
+  name                = "trigger_transfer_monitor_${var.namespace}"
   schedule_expression = "cron(15 6 ? * MON *)"
 }
 


### PR DESCRIPTION
The transfer monitor provides end-to-end testing of Archivematica – it looks at the files uploaded to the S3 bucket as Archivematica inputs, and checks to see if they've successfully reached the storage service. It does that by looking for the METS file in the reporting cluster. Unfortunately, the name of that file is structured in a way that makes it slightly difficult to query:

    data/objects/submissionDocumentation/transfer-ARTCOOB14-46f0a350-d18d-4123-a162-70589bf9786e/METS.xml

So the monitor has to query the list of storage service files in an approximate way:

    SELECT files
    WHERE externalIdentifier={archivematicaIdentifier}
    AND suffix=".xml"

which can fail if a bag contains lots of XML files and the METS file isn't in the first page of results.

We can fix this in the storage service, but we haven't done that work yet. See https://github.com/wellcomecollection/storage-service/issues/1028

This ups the result window from 100 to 10,000, so it's more likely we'll find the METS file in that first page of results.  If this still isn't enough, we can go back to the storage service.