### PR TITLE
Upgrade to the newest version of Redis/ElastiCache

### DIFF
--- a/terraform/modules/critical/elasticache.tf
+++ b/terraform/modules/critical/elasticache.tf
@@ -15,8 +15,8 @@ resource "aws_elasticache_cluster" "archivematica" {
   engine               = "redis"
   node_type            = "cache.m3.medium"
   num_cache_nodes      = 1
-  parameter_group_name = "default.redis3.2"
-  engine_version       = "3.2.10"
+  parameter_group_name = "default.redis7"
+  engine_version       = "7.x"
   port                 = 6379
 
   subnet_group_name  = aws_elasticache_subnet_group.archivematica.name


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/archivematica-infrastructure/issues/118

I actually applied this upgrade in the console and then did a no-op plan/apply in Terraform. I've also tested it against the staging instance; it works as-expected.