### PR TITLE
Archivematica only needs PutObject here, not Put*

### DIFF
--- a/terraform/modules/stack/iam.tf
+++ b/terraform/modules/stack/iam.tf
@@ -6,11 +6,10 @@ resource "aws_iam_role_policy" "storage_service_task_role_policy" {
 data "aws_iam_policy_document" "storage_service_aws_permissions" {
   statement {
     actions = [
-      "s3:Put*",
+      "s3:PutObject",
     ]
 
     resources = [
-      var.ingests_bucket_arn,
       "${var.ingests_bucket_arn}/*",
     ]
   }


### PR DESCRIPTION
I've been chatting about our IAM policies to Hillel Arnold at Rockefeller, and he asked why Archivematica has `Put*` here when it's only doing `PutObject`. This tightens the permission to what we're actually using.

I've run a test transfer in staging to confirm this works correctly.