### PR TITLE
Bump the resources available to the clamav service

### DIFF
--- a/terraform/modules/stack/services.tf
+++ b/terraform/modules/stack/services.tf
@@ -102,8 +102,8 @@ module "clamav_service" {
 
   desired_task_count = 2
 
-  cpu    = 1 * 1024
-  memory = 3 * 1024
+  cpu    = 2 * 1024
+  memory = 4 * 1024
 
   cluster_arn  = aws_ecs_cluster.archivematica.arn
   namespace    = var.namespace


### PR DESCRIPTION
## What does this change

This change increases the CPU and memory resources available to the clamav archivematica service. We've seen repeated failures in this service, with metrics indicating CPU usage is capping out at 100% on occasion.

Failures:
<img width="722" alt="Screenshot 2024-01-05 at 14 55 15" src="https://github.com/wellcomecollection/archivematica-infrastructure/assets/953792/bdeaff36-7a35-49d2-aab3-99fc4c38c930">

Metrics:
<img width="617" alt="Screenshot 2024-01-05 at 15 11 16" src="https://github.com/wellcomecollection/archivematica-infrastructure/assets/953792/e1597468-d18a-4c0a-b55a-c2d73dd8fd2e">

We hope to mitigate this issue by naively increasing resources to see if it has an impact. Increase to Fargate resources need to meet some [size requirements](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html#fargate-tasks-size), and have [associated costs](https://aws.amazon.com/fargate/pricing/).

> [!NOTE]
> This change will result in a cost increase.
> Presuming 720 hours in a month, the calculation is ((hours * cost of 1vCPU * num vCPUs) + (hours * cost of 1GB memory * number of GB)) * number of tasks.
> Before: 
> ((720 * 0.04048 *1) + (720 * 0.004445 * 3) * 2) = $48.35
> After:
> ((720 * 0.04048 *2) + (720 * 0.004445 * 4) * 2) = $83.89

## Who is this change for?

This change hopefully reduces manual work for folk working with Archivematica attempting to get things ingested to the storage service.
