### PR TITLE
log into ECR with get-login-password

### DIFF
--- a/.buildkite/scripts/publish_docker_image.sh
+++ b/.buildkite/scripts/publish_docker_image.sh
@@ -12,7 +12,10 @@ CURRENT_COMMIT=$(git log -1 --pretty=format:"%H" archivematica-apps/$SERVICE_ID)
 ROOT=$(git rev-parse --show-toplevel)
 
 echo "*** Logging in to ECR Private"
-eval $(aws ecr get-login --no-include-email --registry-ids "$ACCOUNT_ID")
+aws ecr get-login-password \
+| docker login \
+    --username AWS \
+    --password-stdin 299497370133.dkr.ecr.eu-west-1.amazonaws.com
 
 LOCAL_IMAGE_TAG="$SERVICE_ID:$CURRENT_COMMIT"
 REMOTE_IMAGE_TAG="$ACCOUNT_ID.dkr.ecr.eu-west-1.amazonaws.com/weco/$LOCAL_IMAGE_TAG"

--- a/archivematica-apps/archivematica-storage-service/build_and_publish_image.sh
+++ b/archivematica-apps/archivematica-storage-service/build_and_publish_image.sh
@@ -8,7 +8,10 @@ ARCHIVEMATICA_TAG=v0.20.1
 ROOT=$(git rev-parse --show-toplevel)
 CURRENT_COMMIT=$(git log -1 --pretty=format:"%H" "$ROOT"/archivematica-apps/archivematica-storage-service)
 
-eval $(aws ecr get-login --no-include-email)
+aws ecr get-login-password \
+| docker login \
+    --username AWS \
+    --password-stdin 299497370133.dkr.ecr.eu-west-1.amazonaws.com
 
 pushd $(mktemp -d)
 

--- a/archivematica-apps/archivematica/build_and_publish_image.sh
+++ b/archivematica-apps/archivematica/build_and_publish_image.sh
@@ -15,7 +15,10 @@ SERVICE="$1"
 ROOT=$(git rev-parse --show-toplevel)
 CURRENT_COMMIT=$(git log -1 --pretty=format:"%H" $ROOT/archivematica-apps/archivematica)
 
-eval $(aws ecr get-login --no-include-email)
+aws ecr get-login-password \
+| docker login \
+    --username AWS \
+    --password-stdin 299497370133.dkr.ecr.eu-west-1.amazonaws.com
 
 pushd $(mktemp -d)
 


### PR DESCRIPTION
## What does this change?
Following the buildkite upgrade, `ecr get-login` doesn't work anymore. Replaced with `ecr get-login-password` then piping the password into the docker container

## How to test
Open a PR and see whether the PR checks pass

## How can we measure success?
We can build archivematica-infrastructure again

## Have we considered potential risks?
This has been applied successfully in other project. We can also check it works properly before even merging the change. 