### PR TITLE
Update container image name, as compose version has been updated

### DIFF
--- a/archivematica-apps/archivematica/build_and_publish_image.sh
+++ b/archivematica-apps/archivematica/build_and_publish_image.sh
@@ -41,7 +41,7 @@ pushd $(mktemp -d)
   echo "*** Pushing to ECR"
 
   ECR_IMAGE_TAG="299497370133.dkr.ecr.eu-west-1.amazonaws.com/weco/archivematica-$SERVICE:$ARCHIVEMATICA_TAG-$CURRENT_COMMIT"
-  docker tag "hack_archivematica-$SERVICE" "$ECR_IMAGE_TAG"
+  docker tag "hack-archivematica-$SERVICE" "$ECR_IMAGE_TAG"
 
   docker push "$ECR_IMAGE_TAG"
 


### PR DESCRIPTION
## What does this change?

This is a fix for https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/issues/410
where the underlying docker compose version has changed, and the naming convention for docker
images has shifted from using an underscore to a hyphen.

We can fix this by updating our build scripts rather than by forcing the docker version of the plugin
as has been done elsewhere (https://github.com/wellcomecollection/content-api/pull/82) as we are not
using the docker-composer plugin.

This change builds on top of https://github.com/wellcomecollection/archivematica-infrastructure/pull/141 and can be merged into that branch before `main`.

## How to test

- [ ] Does the PR get a green tick from CI?

## How can we measure success?

We are able to text and deploy archivematica-infrastructure again, specifically this PR that's waiting to go out: https://github.com/wellcomecollection/archivematica-infrastructure/pull/140

## Have we considered potential risks?

The only reference to this container image name is in the build script, so should not impact other parts of the build process.
