### PR TITLE
Increase the memory available to the transfer_monitor_lambda

### DIFF
--- a/terraform/modules/stack/lambda/lambda_function.tf
+++ b/terraform/modules/stack/lambda/lambda_function.tf
@@ -15,8 +15,8 @@ module "lambda_function" {
 
   handler = var.handler
 
-  runtime = "python3.10"
-  timeout = var.timeout
+  runtime     = "python3.10"
+  timeout     = var.timeout
   memory_size = var.memory_size
 
   environment = {

--- a/terraform/modules/stack/lambda/lambda_function.tf
+++ b/terraform/modules/stack/lambda/lambda_function.tf
@@ -17,6 +17,7 @@ module "lambda_function" {
 
   runtime = "python3.10"
   timeout = var.timeout
+  memory_size = var.memory_size
 
   environment = {
     variables = var.environment

--- a/terraform/modules/stack/lambda/variables.tf
+++ b/terraform/modules/stack/lambda/variables.tf
@@ -27,3 +27,8 @@ variable "timeout" {
   type    = number
   default = 30
 }
+
+variable "memory_size" {
+  type = number
+  default = 128
+}

--- a/terraform/modules/stack/lambda/variables.tf
+++ b/terraform/modules/stack/lambda/variables.tf
@@ -29,6 +29,6 @@ variable "timeout" {
 }
 
 variable "memory_size" {
-  type = number
+  type    = number
   default = 128
 }

--- a/terraform/modules/stack/lambda_transfer_monitor.tf
+++ b/terraform/modules/stack/lambda_transfer_monitor.tf
@@ -7,6 +7,8 @@ module "transfer_monitor_lambda" {
   name            = "archivematica-transfer_monitor-${var.namespace}"
   alarm_topic_arn = var.lambda_error_alarm_arn
 
+  memory_size = 512
+
   environment = {
     TRANSFER_BUCKET       = var.transfer_source_bucket_name
     REPORTING_FILES_INDEX = var.namespace == "prod" ? "storage_files" : "storage_stage_files"


### PR DESCRIPTION
## What does this change?

We've noticed this lambda failing through timeouts. Upon investigation it appears the lambda has been consistently using its entire allocation of 128MB which suggested that it was insufficiently resourced resulting in it locking up and timing out.

After experimentation is seems that 512MB is sufficient to cause the transfer lambda to succeed. 

See:
<img width="1375" alt="Screenshot 2024-01-09 at 12 50 48" src="https://github.com/wellcomecollection/archivematica-infrastructure/assets/953792/4e2f5a1c-8291-4e65-b51b-f82aab4ea860">

> [!NOTE] 
> This has been applied in production to resolve the existing issue as part of testing.

## How to test

- [x] Manual testing to ensure that this resource allocation allows the lambda to suceed.
- [ ] Deploy to production, do we continue to see failures?

## How can we measure success?

This lambda continues to function and report task failures, as well as clearing up the source bucket controlling costs.

## Have we considered potential risks?

This change will result in some increased cost but as this lambda runs quite infrequently the cost change is negligible.
