### PR TITLE
Update clamav, see if it improves the situation

### DIFF
--- a/archivematica-apps/clamavd/Dockerfile
+++ b/archivematica-apps/clamavd/Dockerfile
@@ -1,4 +1,4 @@
-FROM clamav/clamav:0.105
+FROM clamav/clamav:1.2
 
 RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \

--- a/archivematica-apps/clamavd/Dockerfile
+++ b/archivematica-apps/clamavd/Dockerfile
@@ -1,5 +1,4 @@
 FROM clamav/clamav:1.2
 
-RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
-    echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
-    sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
+RUN sed -i 's/^#Foreground .*$/Foreground yes/g' /etc/clamav/clamd.conf && \
+    sed -i 's/^#Foreground .*$/Foreground yes/g' /etc/clamav/freshclam.conf

--- a/terraform/stack_prod/locals.tf
+++ b/terraform/stack_prod/locals.tf
@@ -19,7 +19,7 @@ locals {
     mcp_client         = "v1.14.1-3abac53f15ab2a9ae60f79f68e0ef0c9eb81191c"
     mcp_server         = "v1.14.1-3abac53f15ab2a9ae60f79f68e0ef0c9eb81191c"
     am_storage_service = "v0.20.1-1b8e2c65aff6913122a7de72bc9027f36cf68129"
-    clamavd            = "120f7da2bd3a1377974ae1f5523711694d1ba11c"
+    clamavd            = "f60df7b65fe0e405d89191053f7196a1769e4ccf"
     nginx              = "120f7da2bd3a1377974ae1f5523711694d1ba11c"
   }
 }


### PR DESCRIPTION
## What does this change?

This change updates the version of clamav in use to address https://github.com/wellcomecollection/archivematica-infrastructure/issues/145 (we've continued to see failures even though the tasks have more CPU resource).

The config file format seems to have changed since the pre-1.0 version, so we need to update to ensure we maintain the `Foreground` & `TCPSocket` options.

> [!NOTE]
> This change updates the image used by clamav to the one built and tested by this PR - the image refs are hard coded into the terraform description here so we avoid another PR by this update.

## How to test

- [x] Build and run locally, does clamav start?
- [x] Manually update the PROD clamav task & service to refer to the image built in this PR, does it successfully process transfers?
- [ ] Deploy to PROD, try some test bags and see if they get processed?

## How can we measure success?

Fewer failures of the clamav service.

## Have we considered potential risks?

This is a massive version upgrade, so it may well behave differently in production. However it's easy to revert and re-try bags if this service fails so there is limited risk.

