### PR TITLE
Fix SSH instructions for accessing container host

### DIFF
--- a/docs/debugging-archivematica/ssh-into-container-hosts.md
+++ b/docs/debugging-archivematica/ssh-into-container-hosts.md
@@ -6,6 +6,7 @@ There's [an unmaintained script](https://github.com/alexwlchan/pathscripts/blob/
 
 The Archivematica container hosts aren't connected directly to the Internet; instead you have to go through the bastion host. There are only a handful of EC2 instances in the workflow account:
 
+
 Steps:
 
 1. Download the `wellcomedigitalworkflow` SSH key from Secrets Manager in the platform account.
@@ -24,6 +25,7 @@ Steps:
 5. Find the DNS names of the instances:
    * the public DNS name of the bastion instance
    * the private DNS name of the container instance
+
 6.  SSH through the instances. I feel like there's probably a way to do this a single tunneling command, but I find it easier to move keys around:
 
     ```shell
@@ -37,3 +39,10 @@ Steps:
     # (on the bastion)
     ssh -i key_on_bastion ec2-user@CONTAINER_HOST
     ```
+
+## Interesting locations on the file system
+
+If you are trying to fix an issue with failing ingests, you may wish to look at these locations:
+
+- `/ebs/pipeline-data/`: The folders containing "processing storage" for archivematica (including `currentlyProcessing`)
+- `/ebs/var/archivematica/storage_service/`: The archivematica-storage-service working storage

--- a/docs/debugging-archivematica/ssh-into-container-hosts.md
+++ b/docs/debugging-archivematica/ssh-into-container-hosts.md
@@ -28,10 +28,10 @@ Steps:
 
     ```shell
     # Upload the SSH key to the bastion instance
-    scp -i key_on_local ec2-user@BASTION_HOST:key_on_bastion
+    scp -i key_on_local key_on_local ec2-user@BASTION_HOST:key_on_bastion
 
     # SSH into the bastion instance
-    ssh -i key_on_local ec2-user@BASTION_HOST
+    ssh -i key_on_local key_on_local ec2-user@BASTION_HOST
 
     # SSH from the bastion instance into the private instance
     # (on the bastion)

--- a/docs/debugging-archivematica/ssh-into-container-hosts.md
+++ b/docs/debugging-archivematica/ssh-into-container-hosts.md
@@ -33,7 +33,7 @@ Steps:
     scp -i key_on_local key_on_local ec2-user@BASTION_HOST:key_on_bastion
 
     # SSH into the bastion instance
-    ssh -i key_on_local key_on_local ec2-user@BASTION_HOST
+    ssh -i key_on_local ec2-user@BASTION_HOST
 
     # SSH from the bastion instance into the private instance
     # (on the bastion)


### PR DESCRIPTION
## What does this change?

Tiny change so that the instructions for SSHing to the container host work.

## How to test

- [ ] Try these yourself, can you SSH in?

## How can we measure success?

Users are able to SSH to the archivematica container host and resolve issues.