### PR TITLE
Increase production volume size, to allow more space for ingests & transfers

### DIFF
--- a/terraform/critical_prod/.terraform.lock.hcl
+++ b/terraform/critical_prod/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "4.62.0"
   hashes = [
     "h1:6x4fZWzzoUpQyIa6wl160ONU9o9IRmK6Hivt9zNFDug=",
+    "h1:H/nY2teFoN9LU+Xtc1dx7TGS6w2HrARs0Q7cFb6vbus=",
     "zh:12059dc2b639797b9facb6397ac6aec563891634be8e5aadf3a457590c1147d4",
     "zh:1b3515d70b6998359d0a6d3b3c287940ab2e5c59cd02f95c7d9dab7df76e86b6",
     "zh:423a1d3afdb6b625f2e3b06770ef4324740d400ff1a0d6d566c87d3f841d74fc",

--- a/terraform/critical_prod/main.tf
+++ b/terraform/critical_prod/main.tf
@@ -17,5 +17,5 @@ module "critical" {
 
   unpacker_task_role_arn = data.terraform_remote_state.storage_service_prod.outputs.unpacker_task_role_arn
 
-  ebs_volume_size = 250
+  ebs_volume_size = 500
 }

--- a/terraform/modules/critical/rds.tf
+++ b/terraform/modules/critical/rds.tf
@@ -28,7 +28,7 @@ resource "aws_rds_cluster" "archivematica" {
   vpc_security_group_ids = [aws_security_group.database_sg.id]
 
   engine         = "aurora-mysql"
-  engine_version = "5.7.mysql_aurora.2.11.0"
+  engine_version = "5.7.mysql_aurora.2.11.2"
 }
 
 resource "aws_rds_cluster_instance" "archivematica" {


### PR DESCRIPTION
## What does this change?

This change increases the volume size for the prod EC2 instance supporting transfers and ingests to 500GB from 250 GB as we are seeing instances where we run out of space. 

Previously the volume size has been decreased considerably, we're being slightly less conservative: https://github.com/wellcomecollection/archivematica-infrastructure/pull/129

See: https://wellcome.slack.com/archives/C02ANCYL90E/p1706707557482739

We should follow the instructions for nitro instances here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/recognize-expanded-volume-linux.html

## How to test

- [ ] SSH into the prod volume and see that the disk space for the `/ebs` volume has increased.

## How can we measure success?

@aray-wellcome can ingest larger things into the storage service without issue.

## Have we considered potential risks?

Changing the volume size involves updating the existing EBS volume in place. If things go wrong we could corrupt the volume making it hard to get set up again. We should snapshot the existing volume as recommended in case there is any such issue.
