### PR TITLE
turn_off_outside_office_hours default true

### DIFF
--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -22,11 +22,6 @@ module "stack" {
 
   namespace = "staging"
 
-  # Normally we turn off the Archivematica services outside working hours,
-  # but we've temporarily disabled this while Artefactual are doing testing
-  # with our Archivematica instance as part of a3m testing.
-  turn_off_outside_office_hours = false
-
   redis_server = data.terraform_remote_state.critical.outputs.redis_server
   redis_port   = data.terraform_remote_state.critical.outputs.redis_port
 


### PR DESCRIPTION
## What does this change?

APPLIED
https://github.com/wellcomecollection/editorial-photography-ingest/issues/28

## How to test

Once applied, check the events tab for these services in the AWS console. It should have a scale down event at the end of the day, and come back up in the morning.

## How can we measure success?

`archivematica-staging` shuts down outside office hours. 

## Have we considered potential risks?

Services can be restarted manually if it fails to come back up
This is the staging cluster, that is not used all that much anyway

### `terraform plan` output
```
Terraform will perform the following actions:

  # module.stack.aws_iam_role.scheduler[0] will be created
  + resource "aws_iam_role" "scheduler" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "scheduler.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "archivematica-staging-instance-scheduler"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "Department"                = "Digital Production"
          + "Division"                  = "Culture and Society"
          + "Environment"               = "Staging"
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/archivematica-infrastructure/tree/master/terraform/stack_staging"
          + "Use"                       = "Archivematica"
        }
      + unique_id             = (known after apply)

      + inline_policy (known after apply)
    }

  # module.stack.aws_iam_role_policy.allow_instance_scaling[0] will be created
  + resource "aws_iam_role_policy" "allow_instance_scaling" {
      + id          = (known after apply)
      + name        = (known after apply)
      + name_prefix = (known after apply)
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "ec2:stopInstances",
                          + "ec2:startInstances",
                        ]
                      + Effect   = "Allow"
                      + Resource = "arn:aws:ec2:eu-west-1:299497370133:instance/i-00e70a530ea76c61f"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + role        = "archivematica-staging-instance-scheduler"
    }

  # module.stack.aws_scheduler_schedule.instances_scale_down[0] will be created
  + resource "aws_scheduler_schedule" "instances_scale_down" {
      + arn                          = (known after apply)
      + group_name                   = "default"
      + id                           = (known after apply)
      + name                         = "archivematica-staging-instances-scale-down"
      + name_prefix                  = (known after apply)
      + schedule_expression          = "cron(0 19 ? * MON,TUE,WED,THUR,FRI *)"
      + schedule_expression_timezone = "UTC"
      + state                        = "ENABLED"

      + flexible_time_window {
          + mode = "OFF"
        }

      + target {
          + arn      = "arn:aws:scheduler:::aws-sdk:ec2:stopInstances"
          + input    = jsonencode(
                {
                  + InstanceIds = [
                      + "i-00e70a530ea76c61f",
                    ]
                }
            )
          + role_arn = (known after apply)
        }
    }

  # module.stack.aws_scheduler_schedule.instances_scale_up[0] will be created
  + resource "aws_scheduler_schedule" "instances_scale_up" {
      + arn                          = (known after apply)
      + group_name                   = "default"
      + id                           = (known after apply)
      + name                         = "archivematica-staging-instances-scale-up"
      + name_prefix                  = (known after apply)
      + schedule_expression          = "cron(0 7 ? * MON,TUE,WED,THUR,FRI *)"
      + schedule_expression_timezone = "UTC"
      + state                        = "ENABLED"

      + flexible_time_window {
          + mode = "OFF"
        }

      + target {
          + arn      = "arn:aws:scheduler:::aws-sdk:ec2:startInstances"
          + input    = jsonencode(
                {
                  + InstanceIds = [
                      + "i-00e70a530ea76c61f",
                    ]
                }
            )
          + role_arn = (known after apply)
        }
    }

  # module.stack.module.clamav_service.module.service.module.service.aws_iam_role.scheduler[0] will be created
  + resource "aws_iam_role" "scheduler" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "scheduler.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "am-staging-clamav-office-hours-scaling"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "Department"                = "Digital Production"
          + "Division"                  = "Culture and Society"
          + "Environment"               = "Staging"
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/archivematica-infrastructure/tree/master/terraform/stack_staging"
          + "Use"                       = "Archivematica"
        }
      + unique_id             = (known after apply)

      + inline_policy (known after apply)
    }

  # module.stack.module.clamav_service.module.service.module.service.aws_iam_role_policy.allow_update_service[0] will be created
  + resource "aws_iam_role_policy" "allow_update_service" {
      + id          = (known after apply)
      + name        = (known after apply)
      + name_prefix = (known after apply)
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = "ecs:UpdateService"
                      + Effect   = "Allow"
                      + Resource = "arn:aws:ecs:eu-west-1:299497370133:service/archivematica-staging/am-staging-clamav"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + role        = "am-staging-clamav-office-hours-scaling"
    }

  # module.stack.module.clamav_service.module.service.module.service.aws_scheduler_schedule.turn_off_in_the_evening[0] will be created
  + resource "aws_scheduler_schedule" "turn_off_in_the_evening" {
      + arn                          = (known after apply)
      + group_name                   = "default"
      + id                           = (known after apply)
      + name                         = "am-staging-clamav-turn_off_in_the_evening"
      + name_prefix                  = (known after apply)
      + schedule_expression          = "cron(0 19 ? * MON,TUE,WED,THUR,FRI *)"
      + schedule_expression_timezone = "UTC"
      + state                        = "ENABLED"

      + flexible_time_window {
          + mode = "OFF"
        }

      + target {
          + arn      = "arn:aws:scheduler:::aws-sdk:ecs:updateService"
          + input    = jsonencode(
                {
                  + Cluster      = "arn:aws:ecs:eu-west-1:299497370133:cluster/archivematica-staging"
                  + DesiredCount = 0
                  + Service      = "am-staging-clamav"
                }
            )
          + role_arn = (known after apply)
        }
    }

  # module.stack.module.clamav_service.module.service.module.service.aws_scheduler_schedule.turn_on_in_the_morning[0] will be created
  + resource "aws_scheduler_schedule" "turn_on_in_the_morning" {
      + arn                          = (known after apply)
      + group_name                   = "default"
      + id                           = (known after apply)
      + name                         = "am-staging-clamav-turn_on_in_the_morning"
      + name_prefix                  = (known after apply)
      + schedule_expression          = "cron(0 7 ? * MON,TUE,WED,THUR,FRI *)"
      + schedule_expression_timezone = "UTC"
      + state                        = "ENABLED"

      + flexible_time_window {
          + mode = "OFF"
        }

      + target {
          + arn      = "arn:aws:scheduler:::aws-sdk:ecs:updateService"
          + input    = jsonencode(
                {
                  + Cluster      = "arn:aws:ecs:eu-west-1:299497370133:cluster/archivematica-staging"
                  + DesiredCount = 2
                  + Service      = "am-staging-clamav"
                }
            )
          + role_arn = (known after apply)
        }
    }

  # module.stack.module.gearman_service.module.service.module.service.aws_iam_role.scheduler[0] will be created
  + resource "aws_iam_role" "scheduler" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "scheduler.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "am-staging-gearman-office-hours-scaling"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "Department"                = "Digital Production"
          + "Division"                  = "Culture and Society"
          + "Environment"               = "Staging"
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/archivematica-infrastructure/tree/master/terraform/stack_staging"
          + "Use"                       = "Archivematica"
        }
      + unique_id             = (known after apply)

      + inline_policy (known after apply)
    }

  # module.stack.module.gearman_service.module.service.module.service.aws_iam_role_policy.allow_update_service[0] will be created
  + resource "aws_iam_role_policy" "allow_update_service" {
      + id          = (known after apply)
      + name        = (known after apply)
      + name_prefix = (known after apply)
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = "ecs:UpdateService"
                      + Effect   = "Allow"
                      + Resource = "arn:aws:ecs:eu-west-1:299497370133:service/archivematica-staging/am-staging-gearman"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + role        = "am-staging-gearman-office-hours-scaling"
    }

  # module.stack.module.gearman_service.module.service.module.service.aws_scheduler_schedule.turn_off_in_the_evening[0] will be created
  + resource "aws_scheduler_schedule" "turn_off_in_the_evening" {
      + arn                          = (known after apply)
      + group_name                   = "default"
      + id                           = (known after apply)
      + name                         = "am-staging-gearman-turn_off_in_the_evening"
      + name_prefix                  = (known after apply)
      + schedule_expression          = "cron(0 19 ? * MON,TUE,WED,THUR,FRI *)"
      + schedule_expression_timezone = "UTC"
      + state                        = "ENABLED"

      + flexible_time_window {
          + mode = "OFF"
        }

      + target {
          + arn      = "arn:aws:scheduler:::aws-sdk:ecs:updateService"
          + input    = jsonencode(
                {
                  + Cluster      = "arn:aws:ecs:eu-west-1:299497370133:cluster/archivematica-staging"
                  + DesiredCount = 0
                  + Service      = "am-staging-gearman"
                }
            )
          + role_arn = (known after apply)
        }
    }

  # module.stack.module.gearman_service.module.service.module.service.aws_scheduler_schedule.turn_on_in_the_morning[0] will be created
  + resource "aws_scheduler_schedule" "turn_on_in_the_morning" {
      + arn                          = (known after apply)
      + group_name                   = "default"
      + id                           = (known after apply)
      + name                         = "am-staging-gearman-turn_on_in_the_morning"
      + name_prefix                  = (known after apply)
      + schedule_expression          = "cron(0 7 ? * MON,TUE,WED,THUR,FRI *)"
      + schedule_expression_timezone = "UTC"
      + state                        = "ENABLED"

      + flexible_time_window {
          + mode = "OFF"
        }

      + target {
          + arn      = "arn:aws:scheduler:::aws-sdk:ecs:updateService"
          + input    = jsonencode(
                {
                  + Cluster      = "arn:aws:ecs:eu-west-1:299497370133:cluster/archivematica-staging"
                  + DesiredCount = 1
                  + Service      = "am-staging-gearman"
                }
            )
          + role_arn = (known after apply)
        }
    }

Plan: 12 to add, 0 to change, 0 to destroy.
```
