### PR TITLE
Add demonstration RDS migration module

### DIFF
--- a/terraform/critical_prod/main.tf
+++ b/terraform/critical_prod/main.tf
@@ -8,6 +8,8 @@ module "critical" {
     aws.digitisation = aws.digitisation
   }
 
+  snapshot_identifier = "archivematica-DOESNOTEXISTYET"
+
   network_private_subnets = data.terraform_remote_state.workflow.outputs.private_subnets
 
   vpc_id = data.terraform_remote_state.workflow.outputs.vpc_id

--- a/terraform/critical_staging/main.tf
+++ b/terraform/critical_staging/main.tf
@@ -8,6 +8,8 @@ module "critical" {
     aws.digitisation = aws.digitisation
   }
 
+  snapshot_identifier = "archivematica-DOESNOTEXISTYET"
+
   network_private_subnets = data.terraform_remote_state.workflow.outputs.private_subnets
   vpc_id                  = data.terraform_remote_state.workflow.outputs.vpc_id
 

--- a/terraform/modules/critical/outputs.tf
+++ b/terraform/modules/critical/outputs.tf
@@ -10,13 +10,17 @@ output "interservice_security_group_id" {
   value = aws_security_group.interservice.id
 }
 
+// NOTE: In order to switch databases, replace with "value = aws_rds_cluster.archivematica.endpoint"
 output "rds_host" {
   value = aws_rds_cluster.archivematica.endpoint
 }
-
+// NOTE: In order to switch databases, replace with "value = aws_rds_cluster.archivematica.endpoint"
 output "rds_port" {
   value = aws_rds_cluster.archivematica.port
 }
+
+// NOTE: During migration, apply the critical stack first, then the associated stage/prod stack.
+// The prod/stage stack read from the critical stack state outputs when applied!
 
 output "ingests_bucket_arn" {
   value = aws_s3_bucket.archivematica_ingests.arn

--- a/terraform/modules/critical/rds.tf
+++ b/terraform/modules/critical/rds.tf
@@ -99,3 +99,20 @@ resource "aws_security_group" "database_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
+// NOTE: When migration is complete, we can remove the aws_rds_cluster, and aws_rds_cluster_instance resources above.
+module "aurora_rds_cluster" {
+  source = "../rds"
+
+  cluster_identifier = "${local.cluster_identifier}-mysql8-aurora3"
+  database_name      = local.database_name
+  master_username    = var.rds_username
+  master_password    = var.rds_password
+
+  db_security_group_id     = aws_security_group.database_sg.id
+  aws_db_subnet_group_name = aws_db_subnet_group.archivematica.name
+
+  snapshot_identifier = var.snapshot_identifier
+
+  engine_version = "8.0.mysql_aurora.3.07.1"
+}

--- a/terraform/modules/critical/variables.tf
+++ b/terraform/modules/critical/variables.tf
@@ -12,3 +12,6 @@ variable "ebs_volume_size" {
   description = "How much EBS storage you need. A good rule of thumb is to have ~3x the size of the largest package you expect to process."
   type        = number
 }
+variable "snapshot_identifier" {
+  type = string 
+}

--- a/terraform/modules/critical/variables.tf
+++ b/terraform/modules/critical/variables.tf
@@ -13,5 +13,5 @@ variable "ebs_volume_size" {
   type        = number
 }
 variable "snapshot_identifier" {
-  type = string 
+  type = string
 }

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -1,0 +1,39 @@
+resource "aws_rds_cluster" "cluster" {
+  cluster_identifier = var.cluster_identifier
+  database_name      = var.database_name
+  master_username    = var.master_username
+  master_password    = var.master_password
+
+  snapshot_identifier = var.snapshot_identifier
+
+  engine         = "aurora-mysql"
+  engine_mode    = "provisioned"
+  engine_version = var.engine_version
+
+  db_subnet_group_name   = var.aws_db_subnet_group_name
+  vpc_security_group_ids = [var.db_security_group_id]
+
+  storage_encrypted    = false
+  enable_http_endpoint = true
+  deletion_protection  = true
+
+  serverlessv2_scaling_configuration {
+    max_capacity = var.max_scaling_capacity
+    min_capacity = var.min_scaling_capacity
+  }
+}
+
+resource "aws_rds_cluster_instance" "migration_instance" {
+  cluster_identifier = aws_rds_cluster.cluster.id
+  instance_class     = var.migration_instance_class
+  engine             = aws_rds_cluster.cluster.engine
+  engine_version     = aws_rds_cluster.cluster.engine_version
+}
+
+# NOTE: This can be uncommented during serverless migration
+# resource "aws_rds_cluster_instance" "serverless_instance" {
+#   cluster_identifier = aws_rds_cluster.cluster.id
+#   instance_class     = "db.serverless"
+#   engine             = aws_rds_cluster.cluster.engine
+#   engine_version     = aws_rds_cluster.cluster.engine_version
+# }

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -1,0 +1,11 @@
+output "rds_cluster_id" {
+  value = aws_rds_cluster.cluster.id
+}
+
+output "rds_host" {
+  value = aws_rds_cluster.cluster.endpoint
+}
+
+output "rds_port" {
+  value = aws_rds_cluster.cluster.port
+}

--- a/terraform/modules/rds/secrets.tf
+++ b/terraform/modules/rds/secrets.tf
@@ -1,0 +1,13 @@
+module "secrets" {
+  source = "github.com/wellcomecollection/terraform-aws-secrets.git?ref=v1.2.0"
+
+  key_value_map = {
+    "rds/${var.cluster_identifier}/endpoint"        = aws_rds_cluster.cluster.endpoint
+    "rds/${var.cluster_identifier}/reader_endpoint" = aws_rds_cluster.cluster.reader_endpoint
+    "rds/${var.cluster_identifier}/port"            = aws_rds_cluster.cluster.port
+  }
+}
+
+variable "engine_version" {
+  type = string
+}

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -39,6 +39,6 @@ variable "min_scaling_capacity" {
 }
 
 variable "migration_instance_class" {
-  type = string
+  type    = string
   default = "db.t4g.medium"
 }

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,0 +1,44 @@
+variable "cluster_identifier" {
+  type    = string
+  default = null
+}
+
+variable "database_name" {
+  type = string
+}
+
+variable "master_username" {
+  type = string
+}
+
+variable "master_password" {
+  type = string
+}
+
+variable "db_security_group_id" {
+  type = string
+}
+
+variable "aws_db_subnet_group_name" {
+  type = string
+}
+
+variable "snapshot_identifier" {
+  type = string
+}
+
+
+variable "max_scaling_capacity" {
+  type    = number
+  default = 8.0
+}
+
+variable "min_scaling_capacity" {
+  type    = number
+  default = 0.5
+}
+
+variable "migration_instance_class" {
+  type = string
+  default = "db.t4g.medium"
+}


### PR DESCRIPTION
## What does this change?

This change is intended to demonstrate an example of how an RDS database migration may proceed.

To apply this change, you would:

- Manually create a snapshot of the database you wish to migrate in the RDS console
- Record the snapshot identifiers and reference them in the `critical_stage` terraform stack
- `plan` / `apply` a terraform change in the `critical_stage` stack to create the new module
- Update the variables in the`stage` stack to output the endpoint & port for the new database
- `plan` / `apply` a terraform change in the `stage` stack to create use new module

Once you are happy this will behave as expected this can be rolled out to the `prod` stack.

In order to proceed with a migration to serverless the following procedure can be followed:

- Uncomment the "serverless instance" resource in the `rds` module 
- `plan` / `apply` a terraform change in the `critical_stage` stack to create the new instance
- Perform a manual "failover" in the AWS console, (select the database instance you wish to failover to in the console click "failover").
- Remove the "migration_instance" resource in the `rds` module 
- `plan` / `apply` a terraform change in the `critical_stage` stack to remove the old instance

Checking again this has not disrupted service, this could be rolled out to prod.

